### PR TITLE
k8s-mesos no longer requires /api suffix for --server arg

### DIFF
--- a/dcos_kubectl/cli.py
+++ b/dcos_kubectl/cli.py
@@ -148,7 +148,7 @@ def main():
 
     rc = call([
         kubectl_path,
-        "--server=" + master + "/api",
+        "--server=" + master,
         "--insecure-skip-tls-verify=" + str(not verify_certs).lower(),
         "--context=dcos-kubectl",  # to nil current context settings
         "--username=dcos-kubectl"  # to avoid username prompt


### PR DESCRIPTION
remove /api suffix from --server for compliance with v0.7.2 k8s-mesos release